### PR TITLE
[AQ-#4] GET /api/version 엔드포인트 추가

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -103,49 +103,20 @@ describe("Health API", () => {
 });
 
 describe("Version API", () => {
-  it("GET /api/version returns correct version information", async () => {
-    const res = await app.request("/api/version");
-    expect(res.status).toBe(200);
-
-    const version = await res.json();
-    expect(version.name).toBe("test-web-app");
-    expect(version.version).toBe("1.0.0");
-    expect(typeof version.nodeVersion).toBe("string");
-    expect(version.nodeVersion).toMatch(/^v\d+\.\d+\.\d+/);
-  });
-
-  it("GET /api/version returns response with correct content type", async () => {
+  it("GET /api/version returns complete version information", async () => {
     const res = await app.request("/api/version");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/json");
-  });
 
-  it("GET /api/version response has exactly the expected fields", async () => {
-    const res = await app.request("/api/version");
     const version = await res.json();
 
+    // Check exact fields
     const expectedFields = ["name", "version", "nodeVersion"];
-    const actualFields = Object.keys(version);
+    expect(Object.keys(version)).toEqual(expectedFields);
 
-    expect(actualFields.length).toBe(expectedFields.length);
-    expectedFields.forEach(field => {
-      expect(actualFields).toContain(field);
-    });
-  });
-
-  it("GET /api/version validates field types and formats", async () => {
-    const res = await app.request("/api/version");
-    const version = await res.json();
-
-    // Name field validation
-    expect(typeof version.name).toBe("string");
-    expect(version.name.length).toBeGreaterThan(0);
-
-    // Version field validation
-    expect(typeof version.version).toBe("string");
-    expect(version.version).toMatch(/^\d+\.\d+\.\d+$/);
-
-    // Node version field validation
+    // Validate field values and types
+    expect(version.name).toBe("test-web-app");
+    expect(version.version).toBe("1.0.0");
     expect(typeof version.nodeVersion).toBe("string");
     expect(version.nodeVersion).toMatch(/^v\d+\.\d+\.\d+/);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,11 @@ const app = new Hono();
 // Track server start time for uptime calculation
 const serverStartTime = Date.now();
 
+// Load package.json once at startup
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJson = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
+
 // Health check endpoint
 app.get("/api/health", (c) => {
   const uptime = Math.floor((Date.now() - serverStartTime) / 1000);
@@ -23,11 +28,6 @@ app.get("/api/health", (c) => {
 
 // Version endpoint
 app.get("/api/version", (c) => {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  const packageJsonPath = join(__dirname, "..", "package.json");
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-
   return c.json({
     name: packageJson.name,
     version: packageJson.version,


### PR DESCRIPTION
## Summary

Resolves #4 — GET /api/version 엔드포인트 추가

애플리케이션의 버전 정보를 확인할 수 있는 REST API가 필요합니다. 클라이언트가 현재 실행 중인 앱의 이름, 버전, 그리고 Node.js 런타임 버전을 조회할 수 있어야 합니다.

## Requirements

- GET /api/version 엔드포인트 구현
- package.json에서 name과 version 정보 읽기
- process.version을 통해 Node.js 버전 정보 포함
- 응답 형태: {"name": "test-web-app", "version": "1.0.0", "nodeVersion": "v20.x.x"}
- 엔드포인트에 대한 테스트 케이스 추가

## Implementation Phases

- Phase 0: Version 엔드포인트 구현 — SUCCESS (fb13fdd3)
- Phase 1: Version 엔드포인트 테스트 추가 — SUCCESS (fc595a65)

## Risks

- package.json 파일 읽기 실패 시 엔드포인트 오류 발생
- process.version의 형태가 예상과 다를 수 있음
- 테스트에서 Node.js 버전이 환경에 따라 달라져 하드코딩된 값과 불일치할 수 있음

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/4-get-api-version` → `main`


Closes #4