### PR TITLE
[AQ-#8] TODO에 createdAt 타임스탬프 추가

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -97,6 +97,157 @@ describe("TODO API", () => {
   });
 });
 
+describe("TODO createdAt functionality", () => {
+  it("createdAt is close to current time when creating a todo", async () => {
+    const beforeCreation = new Date();
+
+    const res = await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Time test" }),
+    });
+
+    const afterCreation = new Date();
+    const todo = await res.json();
+    const todoCreatedAt = new Date(todo.createdAt);
+
+    expect(todoCreatedAt.getTime()).toBeGreaterThanOrEqual(beforeCreation.getTime());
+    expect(todoCreatedAt.getTime()).toBeLessThanOrEqual(afterCreation.getTime());
+  });
+
+  it("multiple todos have createdAt in chronological order", async () => {
+    const res1 = await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "First todo" }),
+    });
+
+    // Small delay to ensure different timestamps
+    await new Promise(resolve => setTimeout(resolve, 1));
+
+    const res2 = await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Second todo" }),
+    });
+
+    const todo1 = await res1.json();
+    const todo2 = await res2.json();
+
+    expect(new Date(todo1.createdAt).getTime()).toBeLessThanOrEqual(new Date(todo2.createdAt).getTime());
+  });
+
+  it("createdAt format is valid ISO 8601 string", async () => {
+    const res = await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "ISO test" }),
+    });
+
+    const todo = await res.json();
+
+    // Check ISO 8601 format
+    expect(todo.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+
+    // Validate it's a parseable date
+    const parsed = new Date(todo.createdAt);
+    expect(parsed.toISOString()).toBe(todo.createdAt);
+    expect(isNaN(parsed.getTime())).toBe(false);
+  });
+
+  it("createdAt remains unchanged when updating todo properties", async () => {
+    const createRes = await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Original title" }),
+    });
+    const originalTodo = await createRes.json();
+
+    // Update title
+    const updateTitleRes = await app.request("/api/todos/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Updated title" }),
+    });
+    const updatedTodo = await updateTitleRes.json();
+
+    expect(updatedTodo.createdAt).toBe(originalTodo.createdAt);
+    expect(updatedTodo.title).toBe("Updated title");
+
+    // Update completed status
+    const updateCompletedRes = await app.request("/api/todos/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ completed: true }),
+    });
+    const finalTodo = await updateCompletedRes.json();
+
+    expect(finalTodo.createdAt).toBe(originalTodo.createdAt);
+    expect(finalTodo.completed).toBe(true);
+  });
+
+  it("each todo gets a createdAt timestamp (may be same for rapid creation)", async () => {
+    const todos = [];
+
+    // Create multiple todos with small delays
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request("/api/todos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: `Todo ${i + 1}` }),
+      });
+      todos.push(await res.json());
+
+      // Small delay to potentially get different timestamps
+      if (i < 2) {
+        await new Promise(resolve => setTimeout(resolve, 2));
+      }
+    }
+
+    // Extract all createdAt values
+    const createdAtValues = todos.map(todo => todo.createdAt);
+
+    // Check that all values are valid timestamps
+    createdAtValues.forEach(createdAt => {
+      expect(typeof createdAt).toBe("string");
+      expect(createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(isNaN(new Date(createdAt).getTime())).toBe(false);
+    });
+
+    // Check that timestamps are in non-decreasing order (allowing for same timestamps)
+    for (let i = 1; i < createdAtValues.length; i++) {
+      const prev = new Date(createdAtValues[i - 1]).getTime();
+      const curr = new Date(createdAtValues[i]).getTime();
+      expect(curr).toBeGreaterThanOrEqual(prev);
+    }
+  });
+
+  it("createdAt is included in todo list response", async () => {
+    await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "List test 1" }),
+    });
+
+    await app.request("/api/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "List test 2" }),
+    });
+
+    const listRes = await app.request("/api/todos");
+    const todoList = await listRes.json();
+
+    expect(todoList).toHaveLength(2);
+
+    todoList.forEach(todo => {
+      expect(todo).toHaveProperty("createdAt");
+      expect(typeof todo.createdAt).toBe("string");
+      expect(todo.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+  });
+});
+
 describe("Health API", () => {
   it("GET /api/health returns correct status and format", async () => {
     const res = await app.request("/api/health");

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -110,16 +110,10 @@ describe("TODO createdAt functionality", () => {
   });
 
   it("createdAt format is valid ISO 8601 string", async () => {
-    const res = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "ISO test" }),
-    });
-
-    const todo = await res.json();
+    const { todo } = await createTodo("ISO test");
 
     // Check ISO 8601 format
-    expect(todo.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(todo.createdAt).toMatch(ISO_8601_REGEX);
 
     // Validate it's a parseable date
     const parsed = new Date(todo.createdAt);
@@ -147,12 +141,8 @@ describe("TODO createdAt functionality", () => {
 
     // Create multiple todos with small delays
     for (let i = 0; i < 3; i++) {
-      const res = await app.request("/api/todos", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: `Todo ${i + 1}` }),
-      });
-      todos.push(await res.json());
+      const { todo } = await createTodo(`Todo ${i + 1}`);
+      todos.push(todo);
 
       // Small delay to potentially get different timestamps
       if (i < 2) {
@@ -179,17 +169,8 @@ describe("TODO createdAt functionality", () => {
   });
 
   it("createdAt is included in todo list response", async () => {
-    await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "List test 1" }),
-    });
-
-    await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "List test 2" }),
-    });
+    await createTodo("List test 1");
+    await createTodo("List test 2");
 
     const listRes = await app.request("/api/todos");
     const todoList = await listRes.json();
@@ -199,7 +180,7 @@ describe("TODO createdAt functionality", () => {
     todoList.forEach(todo => {
       expect(todo).toHaveProperty("createdAt");
       expect(typeof todo.createdAt).toBe("string");
-      expect(todo.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(todo.createdAt).toMatch(ISO_8601_REGEX);
     });
   });
 });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -2,9 +2,20 @@ import { describe, it, expect, beforeEach } from "vitest";
 import app from "./app.js";
 import { resetTodos } from "./todos.js";
 
+const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
 beforeEach(() => {
   resetTodos();
 });
+
+async function createTodo(title: string) {
+  const res = await app.request("/api/todos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title }),
+  });
+  return { res, todo: await res.json() };
+}
 
 describe("TODO API", () => {
   it("GET /api/todos returns empty array initially", async () => {
@@ -14,27 +25,18 @@ describe("TODO API", () => {
   });
 
   it("POST /api/todos creates a todo", async () => {
-    const res = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Buy milk" }),
-    });
+    const { res, todo } = await createTodo("Buy milk");
     expect(res.status).toBe(201);
-    const todo = await res.json();
     expect(todo).toEqual({
       id: 1,
       title: "Buy milk",
       completed: false,
-      createdAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+      createdAt: expect.stringMatching(ISO_8601_REGEX)
     });
   });
 
   it("GET /api/todos/:id returns a specific todo", async () => {
-    await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Test todo" }),
-    });
+    await createTodo("Test todo");
     const res = await app.request("/api/todos/1");
     expect(res.status).toBe(200);
     const todo = await res.json();
@@ -42,7 +44,7 @@ describe("TODO API", () => {
       id: 1,
       title: "Test todo",
       completed: false,
-      createdAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+      createdAt: expect.stringMatching(ISO_8601_REGEX)
     });
   });
 
@@ -52,12 +54,7 @@ describe("TODO API", () => {
   });
 
   it("PATCH /api/todos/:id updates a todo", async () => {
-    const createRes = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Original" }),
-    });
-    const createdTodo = await createRes.json();
+    const { todo: createdTodo } = await createTodo("Original");
 
     const res = await app.request("/api/todos/1", {
       method: "PATCH",
@@ -70,16 +67,12 @@ describe("TODO API", () => {
       id: 1,
       title: "Original",
       completed: true,
-      createdAt: createdTodo.createdAt // createdAt should remain unchanged
+      createdAt: createdTodo.createdAt
     });
   });
 
   it("DELETE /api/todos/:id deletes a todo", async () => {
-    await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "To delete" }),
-    });
+    await createTodo("To delete");
     const res = await app.request("/api/todos/1", { method: "DELETE" });
     expect(res.status).toBe(200);
 
@@ -100,39 +93,18 @@ describe("TODO API", () => {
 describe("TODO createdAt functionality", () => {
   it("createdAt is close to current time when creating a todo", async () => {
     const beforeCreation = new Date();
-
-    const res = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Time test" }),
-    });
-
+    const { todo } = await createTodo("Time test");
     const afterCreation = new Date();
-    const todo = await res.json();
-    const todoCreatedAt = new Date(todo.createdAt);
 
+    const todoCreatedAt = new Date(todo.createdAt);
     expect(todoCreatedAt.getTime()).toBeGreaterThanOrEqual(beforeCreation.getTime());
     expect(todoCreatedAt.getTime()).toBeLessThanOrEqual(afterCreation.getTime());
   });
 
   it("multiple todos have createdAt in chronological order", async () => {
-    const res1 = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "First todo" }),
-    });
-
-    // Small delay to ensure different timestamps
+    const { todo: todo1 } = await createTodo("First todo");
     await new Promise(resolve => setTimeout(resolve, 1));
-
-    const res2 = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Second todo" }),
-    });
-
-    const todo1 = await res1.json();
-    const todo2 = await res2.json();
+    const { todo: todo2 } = await createTodo("Second todo");
 
     expect(new Date(todo1.createdAt).getTime()).toBeLessThanOrEqual(new Date(todo2.createdAt).getTime());
   });
@@ -156,34 +128,18 @@ describe("TODO createdAt functionality", () => {
   });
 
   it("createdAt remains unchanged when updating todo properties", async () => {
-    const createRes = await app.request("/api/todos", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Original title" }),
-    });
-    const originalTodo = await createRes.json();
+    const { todo: originalTodo } = await createTodo("Original title");
 
-    // Update title
-    const updateTitleRes = await app.request("/api/todos/1", {
+    const updateRes = await app.request("/api/todos/1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "Updated title" }),
+      body: JSON.stringify({ title: "Updated title", completed: true }),
     });
-    const updatedTodo = await updateTitleRes.json();
+    const updatedTodo = await updateRes.json();
 
     expect(updatedTodo.createdAt).toBe(originalTodo.createdAt);
     expect(updatedTodo.title).toBe("Updated title");
-
-    // Update completed status
-    const updateCompletedRes = await app.request("/api/todos/1", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ completed: true }),
-    });
-    const finalTodo = await updateCompletedRes.json();
-
-    expect(finalTodo.createdAt).toBe(originalTodo.createdAt);
-    expect(finalTodo.completed).toBe(true);
+    expect(updatedTodo.completed).toBe(true);
   });
 
   it("each todo gets a createdAt timestamp (may be same for rapid creation)", async () => {
@@ -210,7 +166,7 @@ describe("TODO createdAt functionality", () => {
     // Check that all values are valid timestamps
     createdAtValues.forEach(createdAt => {
       expect(typeof createdAt).toBe("string");
-      expect(createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(createdAt).toMatch(ISO_8601_REGEX);
       expect(isNaN(new Date(createdAt).getTime())).toBe(false);
     });
 

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -21,7 +21,12 @@ describe("TODO API", () => {
     });
     expect(res.status).toBe(201);
     const todo = await res.json();
-    expect(todo).toEqual({ id: 1, title: "Buy milk", completed: false });
+    expect(todo).toEqual({
+      id: 1,
+      title: "Buy milk",
+      completed: false,
+      createdAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    });
   });
 
   it("GET /api/todos/:id returns a specific todo", async () => {

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -38,7 +38,12 @@ describe("TODO API", () => {
     const res = await app.request("/api/todos/1");
     expect(res.status).toBe(200);
     const todo = await res.json();
-    expect(todo.title).toBe("Test todo");
+    expect(todo).toEqual({
+      id: 1,
+      title: "Test todo",
+      completed: false,
+      createdAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    });
   });
 
   it("GET /api/todos/:id returns 404 for non-existent todo", async () => {
@@ -47,11 +52,13 @@ describe("TODO API", () => {
   });
 
   it("PATCH /api/todos/:id updates a todo", async () => {
-    await app.request("/api/todos", {
+    const createRes = await app.request("/api/todos", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "Original" }),
     });
+    const createdTodo = await createRes.json();
+
     const res = await app.request("/api/todos/1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -59,7 +66,12 @@ describe("TODO API", () => {
     });
     expect(res.status).toBe(200);
     const todo = await res.json();
-    expect(todo.completed).toBe(true);
+    expect(todo).toEqual({
+      id: 1,
+      title: "Original",
+      completed: true,
+      createdAt: createdTodo.createdAt // createdAt should remain unchanged
+    });
   });
 
   it("DELETE /api/todos/:id deletes a todo", async () => {

--- a/src/todos.ts
+++ b/src/todos.ts
@@ -2,6 +2,7 @@ export interface Todo {
   id: number;
   title: string;
   completed: boolean;
+  createdAt: string;
 }
 
 let todos: Todo[] = [];
@@ -16,7 +17,7 @@ export function getTodoById(id: number): Todo | undefined {
 }
 
 export function createTodo(title: string): Todo {
-  const todo: Todo = { id: nextId++, title, completed: false };
+  const todo: Todo = { id: nextId++, title, completed: false, createdAt: new Date().toISOString() };
   todos.push(todo);
   return todo;
 }


### PR DESCRIPTION
## Summary

Resolves #8 — TODO에 createdAt 타임스탬프 추가

현재 TODO 엔티티에는 생성 시간 정보가 없어서 언제 TODO가 만들어졌는지 추적할 수 없습니다. 사용자가 TODO의 생성 시점을 확인할 수 있도록 createdAt 필드를 추가해야 합니다.

## Requirements

- Todo 인터페이스에 createdAt: string 필드 추가 (ISO 8601 형식)
- POST /api/todos 엔드포인트에서 TODO 생성 시 자동으로 현재 시간을 createdAt에 설정
- GET /api/todos 및 GET /api/todos/:id 응답에 createdAt 필드 포함
- 기존 테스트가 깨지지 않도록 호환성 유지
- createdAt 필드에 대한 새로운 테스트 케이스 추가

## Implementation Phases

- Phase 0: Todo 인터페이스 및 생성 로직 수정 — SUCCESS (c79edd24)
- Phase 1: 기존 테스트 호환성 수정 — SUCCESS (e70eb5b6)
- Phase 2: createdAt 기능 테스트 추가 — SUCCESS (38a2b698)

## Risks

- 기존 테스트가 예상하지 않은 createdAt 필드로 인해 실패할 수 있음
- ISO 8601 형식 타임스탬프 생성 로직에서 타임존 처리 이슈 가능성
- 기존 API 클라이언트가 응답 구조 변경으로 인해 영향받을 수 있음

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/8-todo-createdat` → `main`


Closes #8